### PR TITLE
Fix NaN metric from crashing dataparallel

### DIFF
--- a/enn_trainer/train.py
+++ b/enn_trainer/train.py
@@ -573,7 +573,8 @@ def train(
         y_pred, y_true = b_values.cpu().numpy(), b_returns.cpu().numpy()
         var_y = np.var(y_true)
         explained_var = torch.tensor(
-            np.nan if var_y == 0 else 1 - np.var(y_true - y_pred) / var_y, dtype=torch.float
+            np.nan if var_y == 0 else 1 - np.var(y_true - y_pred) / var_y,
+            dtype=torch.float,
         )
         clipfrac = torch.tensor(np.mean(clipfracs))
         if parallelism > 1:

--- a/enn_trainer/train.py
+++ b/enn_trainer/train.py
@@ -573,7 +573,7 @@ def train(
         y_pred, y_true = b_values.cpu().numpy(), b_returns.cpu().numpy()
         var_y = np.var(y_true)
         explained_var = torch.tensor(
-            np.nan if var_y == 0 else 1 - np.var(y_true - y_pred) / var_y
+            np.nan if var_y == 0 else 1 - np.var(y_true - y_pred) / var_y, dtype=torch.float
         )
         clipfrac = torch.tensor(np.mean(clipfracs))
         if parallelism > 1:


### PR DESCRIPTION
Setting the `explained_variance` to `torch.tensor(np.nan)` yields an `fp64` tensor, which causes the data-parallel metrics allreduce to crash when the `dtype` of `explained_variance` is `fp32`.