### PR TITLE
Don’t allow eval processes to exceed eval num_envs

### DIFF
--- a/enn_trainer/eval.py
+++ b/enn_trainer/eval.py
@@ -34,8 +34,10 @@ def run_eval(
     parallelism: int,
 ) -> None:
     # TODO: metrics are biased towards short episodes
-    processes = cfg.processes or rollout.processes
     num_envs = cfg.num_envs or rollout.num_envs
+    processes = cfg.processes
+    if processes is None:
+        processes = min(rollout.processes, num_envs)
 
     envs: VecEnv = create_env(
         cfg.env or env_cfg,


### PR DESCRIPTION
Otherwise, we can get an error if eval doesn’t specify processes but does specify num_envs to be below rollout processes because it tries to assign too few envs across too many processes.

An example of this happening is when trying to run the following from https://github.com/entity-neural-network/enn-zoo?tab=readme-ov-file#gym-%C2%B5rts:
```
xvfb-run -a poetry run python enn_zoo/train.py \
    env.id=GymMicrorts \
    rollout.num_envs=24 \
    total_timesteps=1000000 \
    rollout.steps=256 \
    track=true \
    eval.capture_videos=True \
    eval.interval=300000 \
    eval.steps=2000 \
    eval.num_envs=1
```

Change passed pre-commit and pytest.